### PR TITLE
fix mobile styles for boxes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -121,3 +121,9 @@ h2 {
   margin-top: 1rem;
   width: 90%
 }
+
+@media screen and (max-width: 760px) {
+  .learning-goals, .case-study, .ethics-box, .accident-report, .exercise, .interactive {
+    width: 90%;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -49,6 +49,8 @@ h2 {
 
 .learning-goals {
   padding-left: 1em;
+  padding-right: 1em;
+  box-sizing: border-box;
   border: 2px solid dimgray;
   margin: 1em;
   width: 50%;
@@ -60,11 +62,14 @@ h2 {
   width: 90%;
 }
 .learning-goals ul {
+  padding-left: 30px;
   width: 90%;
 }
 
 .case-study {
   padding-left: 1em;
+  padding-right: 1em;
+  box-sizing: border-box;
   border: 2px solid dimgray;
   margin: 1em;
   width: 50%;
@@ -75,6 +80,8 @@ h2 {
 
 .ethics-box {
   padding-left: 1em;
+  padding-right: 1em;
+  box-sizing: border-box;
   border: 2px solid dimgray;
   margin: 1em;
   width: 50%;
@@ -85,6 +92,8 @@ h2 {
 
 .accident-report {
   padding-left: 1em;
+  padding-right: 1em;
+  box-sizing: border-box;
   border: 2px solid dimgray;
   margin: 1em;
   width: 50%;
@@ -95,6 +104,8 @@ h2 {
 
 .exercise {
   padding-left: 1em;
+  padding-right: 1em;
+  box-sizing: border-box;
   border: 2px solid dimgray;
   margin: 1em;
   width: 50%;
@@ -108,6 +119,8 @@ h2 {
 
 .interactive {
   padding-left: 1em;
+  padding-right: 1em;
+  box-sizing: border-box;
   border: 2px solid dimgray;
   margin: 1em;
   width: 50%;
@@ -124,6 +137,6 @@ h2 {
 
 @media screen and (max-width: 760px) {
   .learning-goals, .case-study, .ethics-box, .accident-report, .exercise, .interactive {
-    width: 90%;
+    width: 85%;
   }
 }


### PR DESCRIPTION
See #2. Exact `width` value can be tweaked.

Before:
<img width="341" alt="Screen Shot 2021-09-21 at 10 13 06 PM" src="https://user-images.githubusercontent.com/7227324/134287003-79106c99-e03f-4efb-8570-33ac54270e30.png">

After:
<img width="337" alt="Screen Shot 2021-09-21 at 10 17 01 PM" src="https://user-images.githubusercontent.com/7227324/134287250-d42fa53b-d627-45d8-9df1-9af502bf1b9d.png">
