### PR TITLE
Update 102-rmarkdown.qmd

### DIFF
--- a/102-rmarkdown.qmd
+++ b/102-rmarkdown.qmd
@@ -23,11 +23,12 @@ We need that before we teach you more about R Markdown. But you should feel good
 
 ::: {.callout-note title="exercises"}
 Knit the R Markdown template to Word and PDF to ensure that you can get this to work. Isn't it gratifying?
+A full list of possible output formats is available [here](https://rmarkdown.rstudio.com/formats.html).
 :::
 
 ## Structure of an R Markdown file
 
-An R Markdown file contains several parts. Most essential are the header, the body text, and code chunks. When you knit the resulting document, you will get the output---text combined with the results of running the core---in one of a number of output formats.
+An R Markdown file contains several parts. Most essential are the header, the body text, and code chunks. When you knit the resulting document, you will get the output---text combined with the results of running the code---in one of a number of output formats.
 
 ### Header
 
@@ -42,7 +43,7 @@ output: html_document
 ---
 ```
 
-<!-- For now, go ahead and set `html_document` to `word_docCument`, except if you have strong preferences for `HTML` or `PDF`. -->
+<!-- For now, go ahead and set `html_document` to `word_document`, except if you have strong preferences for `HTML` or `PDF`. -->
 
 ### Body text
 
@@ -50,7 +51,7 @@ The body of the document is where you actually write your reports. This is prima
 
 The beauty of R Markdown is, however, that you can evaluate `R` code right in the text. To do this, you start inline code with \`r, type the code you want to run, and close it again with a \`. Usually, this key is below the escape (`ESC`) key  or next to the left SHIFT button.
 
-For example, if you want to have the result of 48 times 35 in your text, you type \` r 48-35\`, which returns `r 48 - 35`. Please note that if you return a value with many decimals, it will also print these depending on your settings (for example, `r pi`).
+For example, if you want to have the result of 48 minus 35 in your text, you type \` r 48-35\`, which returns `r 48 - 35`. Please note that if you return a value with many decimals, it will also print these depending on your settings (for example, `r pi`). To change the output number of decimals, you have many options depending on whether you want to set the number of decimals for the whole document or just specific code chunks. See examples [here](https://stackoverflow.com/questions/48199137/set-number-of-decimal-places-to-show-in-output). 
 
 ### Code chunks
 


### PR DESCRIPTION
fix typos (e.g., "times" --> "minus"; "core"-->"code")

add some extra reference links (about output formats, decimal places)